### PR TITLE
Add ability for flannel to use IP masq

### DIFF
--- a/jobs/flannel/spec
+++ b/jobs/flannel/spec
@@ -14,3 +14,6 @@ properties:
 
   ip-range:
     description: ip range of flannel overlay network
+  ip-masq:
+    description: "Enable IP masquerading"
+    default: false

--- a/jobs/flannel/templates/bin/ctl
+++ b/jobs/flannel/templates/bin/ctl
@@ -27,6 +27,7 @@ case $1 in
 
     exec /var/vcap/packages/flannel/bin/flanneld \
       -etcd-endpoints="http://<%= properties.apiserver.ip %>:4001" \
+      -ip-masq=<%= properties.ip-masq %> \
       >>$LOG_DIR/$JOB_NAME.log 2>&1
 
     ;;


### PR DESCRIPTION
When using flannel, it is often useful to disable IP masq for the docker daemon, and enable it for flannel. 

Fixes things like: https://stackoverflow.com/questions/37131780/create-a-redis-sentinel-cluster-in-kubernetes-the-redis-master-can-not-get-the

